### PR TITLE
Leverage attackcti for tactic field options

### DIFF
--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -153,12 +153,7 @@ class JiraHandler:
                 sys.exit()
 
             # tactic field options
-            # TODO: instead of creating fixed tactics, this should leverage attackcti
-            payload = [{"name": "command-and-control"}, {"name": "privilege-escalation"}, {"name": "defense-evasion"},
-                       {"name": "exfiltration"}, {"name": "impact"}, {"name": "discovery"}, {"name": "execution"},
-                       {"name": "credential-access"}, {"name": "initial-access"}, {"name": "collection"},
-                       {"name": "lateral-movement"}, {"name": "persistence"}]
-
+            payload = self.get_attack_tactics()
             r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['tactic'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
             if r.status_code != 204:
                 print("[!] Error creating options for the tactic custom field.")
@@ -397,7 +392,11 @@ class JiraHandler:
         try:
             tactics_payload=[]
             client = attack_client()
-            tactics = client.get_tactics()
+            enterprise_tactics = client.get_enterprise()
+            tactics = [tactic['name'].lower().replace(" ", "-") for tactic in enterprise_tactics['tactics']]
+            for tactic in tactics:
+                tactics_payload.append({"name": tactic})
+            return tactics_payload
 
         except:
             traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
I noticed you had a TODO for making use of non-fixed tactics in the custom field options.
Couldn't see a contribution guide for this repo, but I've tested on a free trial of jira - and i'm not sure if you want this to go through your dev branch first.

Notes:
- I replaced method `attack_client.get_tactics()` with `attack_client.enterprise_tactics()` as when it was hard coded, tactics from PRE-ATTACK and Mobile were not used.
- Sometimes people consider the list comprehension used in `get_attack_tactics(`) to be difficult to read. If you'd prefer it to be split up, I am happy to do so. 

From the test, see custom field for tactic:
![image](https://user-images.githubusercontent.com/45727537/95732305-3141b080-0cb3-11eb-9c20-364617cb24ec.png)
