### PR TITLE
Sub technique support and other enhancements

### DIFF
--- a/attack2jira.py
+++ b/attack2jira.py
@@ -135,10 +135,10 @@ class Attack2Jira:
                             # "customfield_11050": "Value that we're putting into a Free Text Field."
                         }
                     }
-                    print("Creating Technique")
+                    #print("Creating Technique")
                     parent_id= jiraclient.create_issue(issue_dict, id)
-                    print (parent_id)
-                    print("Created Technique with id : "+ str(parent_id))
+                    #print (parent_id)
+                    #print("Created Technique with id : "+ str(parent_id))
 
                 else:
                 # Sub-technique
@@ -158,9 +158,9 @@ class Attack2Jira:
                             custom_fields['Sub-Technique of']: jiraclient.url +"/browse/"+parent_id['key'],
                         }
                     }
-                    print("Creating sub Technique under parent " + str(parent_id))
+                    #print("Creating sub Technique under parent " + str(parent_id))
                     ret_id= jiraclient.create_issue(issue_dict, id)
-                    print("Created sub Technique with id : "+ str(ret_id))
+                    #print("Created sub Technique with id : "+ str(ret_id))
 
             except Exception as ex:
                 print("\t[*] Could not create ticket for " + id)
@@ -234,7 +234,7 @@ class Attack2Jira:
         self.jirahandler.create_project(project, key)
         self.jirahandler.create_custom_fields()
         self.jirahandler.add_custom_field_options()
-        self.jirahandler.add_custom_field_to_screen_tab(key)
+        self.jirahandler.add_custom_fields_to_screen(key)
         self.jirahandler.hide_unwanted_fields(key)
         self.create_attack_techniques_and_subtechniques(key)
 

--- a/attack2jira.py
+++ b/attack2jira.py
@@ -87,6 +87,180 @@ class Attack2Jira:
 
         print ("[*] Done!")
 
+    def create_attack_techniques2(self, key):
+
+        jiraclient = self.jirahandler
+        techniques = self.get_attack_techniques()
+        sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
+
+        print ("[*] Creating Jira issues for ATT&CK's techniques...")
+
+        for technique in sorted_techniques:
+            try:
+                custom_fields = self.jirahandler.get_custom_fields()
+
+                name = technique['name']
+                id = technique['external_references'][0]['external_id']
+                url = technique['external_references'][0]['url']
+                tactic = technique['kill_chain_phases'][0]['phase_name']
+                description = technique['description']
+
+                # some techniques dont have the field populated
+                if 'x_mitre_data_sources' in technique.keys():
+                    datasources = technique['x_mitre_data_sources']
+                else:
+                    datasources = []
+
+                ds_payload = []
+                for ds in datasources: ds_payload.append({'value':ds.title()})
+
+                if not technique ['x_mitre_is_subtechnique']:
+                # Not a sub-technique
+                    issue_dict = {
+                        "fields": {
+                            "project": {"key": key },
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            "issuetype": {"name": "Task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                            # "customfield_11050": "Value that we're putting into a Free Text Field."
+                        }
+                    }
+                    print("Creating Technique")
+                    parent_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created Technique with id : "+ str(parent_id))
+
+                else:
+                # Sub-technique
+                    issue_dict = {
+                        "fields": {
+                            "parent": {"id": parent_id['id']},
+                            "project": {"key": key},
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            "issuetype": {"name": "Sub-task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                        },
+                        "update": {
+                            "issuelinks": [
+                                {
+                                    "add": {
+                                        "type": {
+                                            "name": "Relates",
+                                            #"inward": "relates to",
+                                            "outward": "relates to"
+                                        },
+                                        "outwardIssue": {
+                                            "key": parent_id['key']
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                    print("Creating sub Technique under parent " + str(parent_id))
+                    ret_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created sub Technique with id : "+ str(ret_id))
+
+            except Exception as ex:
+                print("\t[*] Could not create ticket for " + id)
+                print(ex)
+                traceback.print_exc(file=sys.stdout)
+                pass
+                # print(ex)
+                # sys.exit()
+
+        print("[*] Done!")
+
+
+    def create_attack_techniques3(self, key):
+
+        jiraclient = self.jirahandler
+        techniques = self.get_attack_techniques()
+        sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
+
+        print ("[*] Creating Jira issues for ATT&CK's techniques...")
+
+        for technique in sorted_techniques:
+            try:
+                custom_fields = self.jirahandler.get_custom_fields()
+
+                name = technique['name']
+                id = technique['external_references'][0]['external_id']
+                url = technique['external_references'][0]['url']
+                tactic = technique['kill_chain_phases'][0]['phase_name']
+                description = technique['description']
+
+                # some techniques dont have the field populated
+                if 'x_mitre_data_sources' in technique.keys():
+                    datasources = technique['x_mitre_data_sources']
+                else:
+                    datasources = []
+
+                ds_payload = []
+                for ds in datasources: ds_payload.append({'value':ds.title()})
+
+                if not technique ['x_mitre_is_subtechnique']:
+                # Not a sub-technique
+                    issue_dict = {
+                        "fields": {
+                            "project": {"key": key },
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            "issuetype": {"name": "Task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                            # "customfield_11050": "Value that we're putting into a Free Text Field."
+                        }
+                    }
+                    print("Creating Technique")
+                    parent_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created Technique with id : "+ str(parent_id))
+
+                else:
+                # Sub-technique
+                    issue_dict = {
+                        "fields": {
+                            "parent": {"id": parent_id['id']},
+                            "project": {"key": key},
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            "issuetype": {"name": "Sub-task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                        }
+                    }
+                    print("Creating sub Technique under parent " + str(parent_id))
+                    ret_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created sub Technique with id : "+ str(ret_id))
+
+            except Exception as ex:
+                print("\t[*] Could not create ticket for " + id)
+                print(ex)
+                traceback.print_exc(file=sys.stdout)
+                pass
+                # print(ex)
+                # sys.exit()
+
+        print("[*] Done!")
 
 
     def generate_json_layer(self, hideDisabled):
@@ -153,7 +327,7 @@ class Attack2Jira:
         self.jirahandler.add_custom_field_options()
         self.jirahandler.add_custom_field_to_screen_tab(key)
         self.jirahandler.hide_unwanted_fields(key)
-        self.create_attack_techniques(key)
+        self.create_attack_techniques2(key)
 
 
 def main():

--- a/attack2jira.py
+++ b/attack2jira.py
@@ -15,6 +15,7 @@ class Attack2Jira:
         self.jirahandler = jirahandler
 
     def get_attack_techniques(self):
+    # Deprecated, keeping just in case
 
         try:
             print ("[*] Obtaining ATT&CK's techniques...")
@@ -87,7 +88,7 @@ class Attack2Jira:
 
         print ("[*] Done!")
 
-    def create_attack_techniques2(self, key):
+    def create_attack_techniques_and_subtechniques(self, key):
 
         # this creates each sub-technique as a SubTask 
         # no issue links are created
@@ -122,8 +123,8 @@ class Attack2Jira:
                     issue_dict = {
                         "fields": {
                             "project": {"key": key },
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
+                            #"summary":  name + " (" + id + ")",
+                            "summary": name,
                             "description": description,
                             "issuetype": {"name": "Task"},
                             custom_fields['Id']: id,
@@ -145,8 +146,8 @@ class Attack2Jira:
                         "fields": {
                             "parent": {"id": parent_id['id']},
                             "project": {"key": key},
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
+                            #"summary":  name + " (" + id + ")",
+                            "summary": name,
                             "description": description,
                             "issuetype": {"name": "Sub-task"},
                             custom_fields['Id']: id,
@@ -170,108 +171,6 @@ class Attack2Jira:
                 # sys.exit()
 
         print("[*] Done!")
-
-    """
-    def create_attack_techniques3(self, key):
-
-        # this creates each sub-technique as a regular Task
-        # Issue links are created between techniques and Sub-techniques.
-        # inward
-
-        jiraclient = self.jirahandler
-        techniques = self.get_attack_techniques()
-        sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
-
-        print ("[*] Creating Jira issues for ATT&CK's techniques...")
-
-        for technique in sorted_techniques:
-            try:
-                custom_fields = self.jirahandler.get_custom_fields()
-
-                name = technique['name']
-                id = technique['external_references'][0]['external_id']
-                url = technique['external_references'][0]['url']
-                tactic = technique['kill_chain_phases'][0]['phase_name']
-                description = technique['description']
-
-                # some techniques dont have the field populated
-                if 'x_mitre_data_sources' in technique.keys():
-                    datasources = technique['x_mitre_data_sources']
-                else:
-                    datasources = []
-
-                ds_payload = []
-                for ds in datasources: ds_payload.append({'value':ds.title()})
-
-                if not technique ['x_mitre_is_subtechnique']:
-                # Not a sub-technique
-                    issue_dict = {
-                        "fields": {
-                            "project": {"key": key },
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
-                            "description": description,
-                            "issuetype": {"name": "Task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
-                            # "customfield_11050": "Value that we're putting into a Free Text Field."
-                        }
-                    }
-                    print("Creating Technique")
-                    parent_id= jiraclient.create_issue(issue_dict, id)
-                    print("Created Technique with id : "+ str(parent_id))
-
-                else:
-                # Sub-technique
-                    issue_dict = {
-                        "fields": {
-                            #"parent": {"id": parent_id['id']},
-                            "project": {"key": key},
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
-                            "description": description,
-                            #"issuetype": {"name": "Sub-task"},
-                            "issuetype": {"name": "Task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
-                        },
-                        "update": {
-                            "issuelinks": [
-                                {
-                                    "add": {
-                                        "type": {
-                                            "name": "Relates",
-                                            "inward": "relates to",
-                                            #"outward": "relates to"
-                                        },
-                                        "inwardIssue": {
-                                            "key": parent_id['key']
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                    print("Creating sub Technique under parent " + str(parent_id))
-                    ret_id= jiraclient.create_issue(issue_dict, id)
-                    print("Created sub Technique with id : "+ str(ret_id))
-
-            except Exception as ex:
-                print("\t[*] Could not create ticket for " + id)
-                print(ex)
-                traceback.print_exc(file=sys.stdout)
-                pass
-                # print(ex)
-                # sys.exit()
-
-        print("[*] Done!")
-    """
 
     def generate_json_layer(self, hideDisabled):
         VERSION = "2.2"
@@ -336,8 +235,8 @@ class Attack2Jira:
         self.jirahandler.create_custom_fields()
         self.jirahandler.add_custom_field_options()
         self.jirahandler.add_custom_field_to_screen_tab(key)
-        self.jirahandler.hide_unwanted_fields2(key)
-        self.create_attack_techniques2(key)
+        self.jirahandler.hide_unwanted_fields(key)
+        self.create_attack_techniques_and_subtechniques(key)
 
 
 def main():

--- a/attack2jira.py
+++ b/attack2jira.py
@@ -434,7 +434,7 @@ class Attack2Jira:
         self.jirahandler.create_custom_fields()
         self.jirahandler.add_custom_field_options()
         self.jirahandler.add_custom_field_to_screen_tab(key)
-        self.jirahandler.hide_unwanted_fields(key)
+        self.jirahandler.hide_unwanted_fields2(key)
         self.create_attack_techniques4(key)
 
 

--- a/attack2jira.py
+++ b/attack2jira.py
@@ -89,6 +89,9 @@ class Attack2Jira:
 
     def create_attack_techniques2(self, key):
 
+        # this creates each sub-technique as a SubTask 
+        # no issue links are created
+
         jiraclient = self.jirahandler
         techniques = self.get_attack_techniques()
         sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
@@ -145,6 +148,91 @@ class Attack2Jira:
                             #"summary": name,
                             "description": description,
                             "issuetype": {"name": "Sub-task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                        }
+                    }
+                    print("Creating sub Technique under parent " + str(parent_id))
+                    ret_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created sub Technique with id : "+ str(ret_id))
+
+            except Exception as ex:
+                print("\t[*] Could not create ticket for " + id)
+                print(ex)
+                traceback.print_exc(file=sys.stdout)
+                pass
+                # print(ex)
+                # sys.exit()
+
+        print("[*] Done!")
+
+
+    def create_attack_techniques3(self, key):
+
+        # this creates each sub-technique as a regular Task
+        # Issue links are created between techniques and Sub-techniques.
+        # outward
+
+        jiraclient = self.jirahandler
+        techniques = self.get_attack_techniques()
+        sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
+
+        print ("[*] Creating Jira issues for ATT&CK's techniques...")
+
+        for technique in sorted_techniques:
+            try:
+                custom_fields = self.jirahandler.get_custom_fields()
+
+                name = technique['name']
+                id = technique['external_references'][0]['external_id']
+                url = technique['external_references'][0]['url']
+                tactic = technique['kill_chain_phases'][0]['phase_name']
+                description = technique['description']
+
+                # some techniques dont have the field populated
+                if 'x_mitre_data_sources' in technique.keys():
+                    datasources = technique['x_mitre_data_sources']
+                else:
+                    datasources = []
+
+                ds_payload = []
+                for ds in datasources: ds_payload.append({'value':ds.title()})
+
+                if not technique ['x_mitre_is_subtechnique']:
+                # Not a sub-technique
+                    issue_dict = {
+                        "fields": {
+                            "project": {"key": key },
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            "issuetype": {"name": "Task"},
+                            custom_fields['id']: id,
+                            custom_fields['tactic']: {'value': tactic},
+                            custom_fields['maturity']: {'value': 'Not Tracked'},
+                            custom_fields['url']: url,
+                            custom_fields['datasources']: ds_payload,
+                            # "customfield_11050": "Value that we're putting into a Free Text Field."
+                        }
+                    }
+                    print("Creating Technique")
+                    parent_id= jiraclient.create_issue(issue_dict, id)
+                    print("Created Technique with id : "+ str(parent_id))
+
+                else:
+                # Sub-technique
+                    issue_dict = {
+                        "fields": {
+                            #"parent": {"id": parent_id['id']},
+                            "project": {"key": key},
+                            "summary":  name + " (" + id + ")",
+                            #"summary": name,
+                            "description": description,
+                            #"issuetype": {"name": "Sub-task"},
+                            "issuetype": {"name": "Task"},
                             custom_fields['id']: id,
                             custom_fields['tactic']: {'value': tactic},
                             custom_fields['maturity']: {'value': 'Not Tracked'},
@@ -183,7 +271,11 @@ class Attack2Jira:
         print("[*] Done!")
 
 
-    def create_attack_techniques3(self, key):
+    def create_attack_techniques4(self, key):
+
+        # this creates each sub-technique as a regular Task
+        # Issue links are created between techniques and Sub-techniques.
+        # inward
 
         jiraclient = self.jirahandler
         techniques = self.get_attack_techniques()
@@ -235,17 +327,34 @@ class Attack2Jira:
                 # Sub-technique
                     issue_dict = {
                         "fields": {
-                            "parent": {"id": parent_id['id']},
+                            #"parent": {"id": parent_id['id']},
                             "project": {"key": key},
                             "summary":  name + " (" + id + ")",
                             #"summary": name,
                             "description": description,
-                            "issuetype": {"name": "Sub-task"},
+                            #"issuetype": {"name": "Sub-task"},
+                            "issuetype": {"name": "Task"},
                             custom_fields['id']: id,
                             custom_fields['tactic']: {'value': tactic},
                             custom_fields['maturity']: {'value': 'Not Tracked'},
                             custom_fields['url']: url,
                             custom_fields['datasources']: ds_payload,
+                        },
+                        "update": {
+                            "issuelinks": [
+                                {
+                                    "add": {
+                                        "type": {
+                                            "name": "Relates",
+                                            "inward": "relates to",
+                                            #"outward": "relates to"
+                                        },
+                                        "inwardIssue": {
+                                            "key": parent_id['key']
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                     print("Creating sub Technique under parent " + str(parent_id))
@@ -261,7 +370,6 @@ class Attack2Jira:
                 # sys.exit()
 
         print("[*] Done!")
-
 
     def generate_json_layer(self, hideDisabled):
         VERSION = "2.2"
@@ -327,7 +435,7 @@ class Attack2Jira:
         self.jirahandler.add_custom_field_options()
         self.jirahandler.add_custom_field_to_screen_tab(key)
         self.jirahandler.hide_unwanted_fields(key)
-        self.create_attack_techniques2(key)
+        self.create_attack_techniques4(key)
 
 
 def main():

--- a/attack2jira.py
+++ b/attack2jira.py
@@ -126,16 +126,17 @@ class Attack2Jira:
                             #"summary": name,
                             "description": description,
                             "issuetype": {"name": "Task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
+                            custom_fields['Id']: id,
+                            custom_fields['Tactic']: {'value': tactic},
+                            custom_fields['Maturity']: {'value': 'Not Tracked'},
+                            custom_fields['Url']: url,
+                            custom_fields['Datasources']: ds_payload,
                             # "customfield_11050": "Value that we're putting into a Free Text Field."
                         }
                     }
                     print("Creating Technique")
                     parent_id= jiraclient.create_issue(issue_dict, id)
+                    print (parent_id)
                     print("Created Technique with id : "+ str(parent_id))
 
                 else:
@@ -148,11 +149,12 @@ class Attack2Jira:
                             #"summary": name,
                             "description": description,
                             "issuetype": {"name": "Sub-task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
+                            custom_fields['Id']: id,
+                            custom_fields['Tactic']: {'value': tactic},
+                            custom_fields['Maturity']: {'value': 'Not Tracked'},
+                            custom_fields['Url']: url,
+                            custom_fields['Datasources']: ds_payload,
+                            custom_fields['Sub-Technique of']: jiraclient.url +"/browse/"+parent_id['key'],
                         }
                     }
                     print("Creating sub Technique under parent " + str(parent_id))
@@ -169,109 +171,8 @@ class Attack2Jira:
 
         print("[*] Done!")
 
-
+    """
     def create_attack_techniques3(self, key):
-
-        # this creates each sub-technique as a regular Task
-        # Issue links are created between techniques and Sub-techniques.
-        # outward
-
-        jiraclient = self.jirahandler
-        techniques = self.get_attack_techniques()
-        sorted_techniques = sorted(techniques, key=lambda k: k['external_references'][0]['external_id'])
-
-        print ("[*] Creating Jira issues for ATT&CK's techniques...")
-
-        for technique in sorted_techniques:
-            try:
-                custom_fields = self.jirahandler.get_custom_fields()
-
-                name = technique['name']
-                id = technique['external_references'][0]['external_id']
-                url = technique['external_references'][0]['url']
-                tactic = technique['kill_chain_phases'][0]['phase_name']
-                description = technique['description']
-
-                # some techniques dont have the field populated
-                if 'x_mitre_data_sources' in technique.keys():
-                    datasources = technique['x_mitre_data_sources']
-                else:
-                    datasources = []
-
-                ds_payload = []
-                for ds in datasources: ds_payload.append({'value':ds.title()})
-
-                if not technique ['x_mitre_is_subtechnique']:
-                # Not a sub-technique
-                    issue_dict = {
-                        "fields": {
-                            "project": {"key": key },
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
-                            "description": description,
-                            "issuetype": {"name": "Task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
-                            # "customfield_11050": "Value that we're putting into a Free Text Field."
-                        }
-                    }
-                    print("Creating Technique")
-                    parent_id= jiraclient.create_issue(issue_dict, id)
-                    print("Created Technique with id : "+ str(parent_id))
-
-                else:
-                # Sub-technique
-                    issue_dict = {
-                        "fields": {
-                            #"parent": {"id": parent_id['id']},
-                            "project": {"key": key},
-                            "summary":  name + " (" + id + ")",
-                            #"summary": name,
-                            "description": description,
-                            #"issuetype": {"name": "Sub-task"},
-                            "issuetype": {"name": "Task"},
-                            custom_fields['id']: id,
-                            custom_fields['tactic']: {'value': tactic},
-                            custom_fields['maturity']: {'value': 'Not Tracked'},
-                            custom_fields['url']: url,
-                            custom_fields['datasources']: ds_payload,
-                        },
-                        "update": {
-                            "issuelinks": [
-                                {
-                                    "add": {
-                                        "type": {
-                                            "name": "Relates",
-                                            #"inward": "relates to",
-                                            "outward": "relates to"
-                                        },
-                                        "outwardIssue": {
-                                            "key": parent_id['key']
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                    print("Creating sub Technique under parent " + str(parent_id))
-                    ret_id= jiraclient.create_issue(issue_dict, id)
-                    print("Created sub Technique with id : "+ str(ret_id))
-
-            except Exception as ex:
-                print("\t[*] Could not create ticket for " + id)
-                print(ex)
-                traceback.print_exc(file=sys.stdout)
-                pass
-                # print(ex)
-                # sys.exit()
-
-        print("[*] Done!")
-
-
-    def create_attack_techniques4(self, key):
 
         # this creates each sub-technique as a regular Task
         # Issue links are created between techniques and Sub-techniques.
@@ -370,6 +271,7 @@ class Attack2Jira:
                 # sys.exit()
 
         print("[*] Done!")
+    """
 
     def generate_json_layer(self, hideDisabled):
         VERSION = "2.2"
@@ -435,7 +337,7 @@ class Attack2Jira:
         self.jirahandler.add_custom_field_options()
         self.jirahandler.add_custom_field_to_screen_tab(key)
         self.jirahandler.hide_unwanted_fields2(key)
-        self.create_attack_techniques4(key)
+        self.create_attack_techniques2(key)
 
 
 def main():

--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -262,8 +262,10 @@ class JiraHandler:
 
             if r.status_code == 201:
                 print ("\t[!] Successfully created Jira issue for "+id)
+                return json.loads(r.text)
             else:
                 print ("\t[!] Error creating Jira issue for "+id)
+                print (r.text)
                 sys.exit()
 
         except Exception as ex:

--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -79,7 +79,7 @@ class JiraHandler:
                 custom_fields=[]
                 custom_field1_dict = {
                     "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:multiselectsearcher",
-                    "name": "tactic",
+                    "name": "Tactic",
                     "description": "Attack Tactic",
                     "type": "com.atlassian.jira.plugin.system.customfieldtypes:select"
                 }
@@ -87,7 +87,7 @@ class JiraHandler:
 
                 custom_field2_dict = {
                     "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:multiselectsearcher",
-                    "name": "maturity",
+                    "name": "Maturity",
                     "description": "Detection Maturity",
                     "type": "com.atlassian.jira.plugin.system.customfieldtypes:select"
                 }
@@ -95,7 +95,7 @@ class JiraHandler:
 
                 custom_field3_dict = {
                     "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher",
-                    "name": "url",
+                    "name": "Url",
                     "description": "Attack Technique Url",
                     "type": "com.atlassian.jira.plugin.system.customfieldtypes:url"
                 }
@@ -103,7 +103,7 @@ class JiraHandler:
 
                 custom_field4_dict = {
                     "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:multiselectsearcher",
-                    "name": "datasources",
+                    "name": "Datasources",
                     "description": "Data Sources",
                     "type": "com.atlassian.jira.plugin.system.customfieldtypes:multiselect"
                 }
@@ -111,11 +111,19 @@ class JiraHandler:
 
                 custom_field5_dict = {
                     "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:textsearcher",
-                    "name": "id",
+                    "name": "Id",
                     "description": "Technique Id",
                     "type": "com.atlassian.jira.plugin.system.customfieldtypes:textfield"
                 }
                 custom_fields.append(custom_field5_dict)
+
+                custom_field6_dict = {
+                    "searcherKey": "com.atlassian.jira.plugin.system.customfieldtypes:textsearcher",
+                    "name": "Sub-Technique of",
+                    "description": "Parent Technique Id",
+                    "type": "com.atlassian.jira.plugin.system.customfieldtypes:textfield"
+                }
+                custom_fields.append(custom_field6_dict)
 
                 for custom_field in custom_fields:
                     r = requests.post(self.url + '/rest/api/3/field', json=custom_field, headers=headers, auth=(self.username, self.apitoken), verify=False)
@@ -147,21 +155,21 @@ class JiraHandler:
 
             # maturity field options
             payload=[{"name":"Not Tracked"},{"name":"Initial"},{"name":"Defined"},{"name":"Resilient"},{"name":"Optimized"}]
-            r=requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/'+custom_fields['maturity'], headers=headers, json= payload, auth=(self.username, self.apitoken),verify=False)
+            r=requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/'+custom_fields['Maturity'], headers=headers, json= payload, auth=(self.username, self.apitoken),verify=False)
             if r.status_code != 204:
                 print("[!] Error creating options for the maturity custom field.")
                 sys.exit()
 
             # tactic field options
             payload = self.get_attack_tactics()
-            r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['tactic'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
+            r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['Tactic'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
             if r.status_code != 204:
                 print("[!] Error creating options for the tactic custom field.")
                 sys.exit()
 
             # data source field options
             payload = self.get_attack_datasources()
-            r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['datasources'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
+            r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['Datasources'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
             if r.status_code != 204:
                 print("[!] Error creating options for the datasources custom field.")
                 sys.exit()
@@ -174,7 +182,7 @@ class JiraHandler:
     def get_custom_fields(self):
 
         #print("[*] Getting custom field ids ...")
-        custom_fields=['tactic','maturity','url','datasources','id']
+        custom_fields=['Tactic','Maturity','Url','Datasources','Id','Sub-Technique of']
         headers = {'Content-Type': 'application/json'}
         resp = dict()
 
@@ -271,7 +279,7 @@ class JiraHandler:
         custom_fields = self.get_custom_fields()
 
         ## TODO: Need to perform better checks but this works for now.
-        if len(custom_fields.keys()) == 5:
+        if len(custom_fields.keys()) == 6:
             return True
         else:
             return False
@@ -384,7 +392,7 @@ class JiraHandler:
                     technique_id = issue['fields'][custom_fields['id']]
                     #print (issue['fields']['summary']," ",issue['fields'][custom_fields['maturity']] )
                     #print(technique_id, " ", issue['fields'][custom_fields['maturity']])
-                    res_dict.update({technique_id:issue['fields'][custom_fields['maturity']]})
+                    res_dict.update({technique_id:issue['fields'][custom_fields['Maturity']]})
                 read_issues+=50
                 startAt+=50
                 if (read_issues>=r.json()['total']):

--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -205,34 +205,8 @@ class JiraHandler:
             traceback.print_exc(file=sys.stdout)
             sys.exit(1)
 
-    """
-    def remove_unwanted_fields(self):
-
-        print("[*] Removing unwanted fields from ATTACK's default screen tab ...")
-        unwanted_fields=['components','fixVersions','versions','reporter','environment','timetracking','timeoriginalestimate','duedate']
-        screen_tab_ids = self.get_screen_tabs()
-
-        headers = {'Content-Type': 'application/json'}
-        try:
-
-            for screen_tab_id in screen_tab_ids:
-                for unwanted_field in unwanted_fields:
-
-                    r = requests.delete(self.url + '/rest/api/2/screens/'+str(screen_tab_id[0])+'/tabs/'+str(screen_tab_id[1])+'/fields/'+unwanted_field+'?undefined', headers=headers, auth=(self.username, self.apitoken), verify=False)
-                    if r.status_code == 204:
-                        print(r.status_code)
-
-                    else:
-                        print("[!] Error removing unwanted fields")
-                        sys.exit(1)
-
-        except Exception as ex:
-            traceback.print_exc(file=sys.stdout)
-            sys.exit(1)
-    """
-
-    def hide_unwanted_fields(self,key):
-
+    def hide_unwanted_fields_old(self,key):
+    # Deprecated, keeping in just in case.
         print("[*] Hiding unnecessary fields from ATTACK's issue layout...")
         screen_tab_ids = self.get_screen_tabs(key)
         headers = {'Content-Type': 'application/json'}
@@ -251,7 +225,7 @@ class JiraHandler:
             traceback.print_exc(file=sys.stdout)
             sys.exit(1)
     
-    def hide_unwanted_fields2(self,key):
+    def hide_unwanted_fields(self,key):
 
         #https://support.atlassian.com/jira-core-cloud/docs/configure-field-layout-in-the-issue-view/
         #https://jira.atlassian.com/browse/JRACLOUD-74697?error=login_required&error_description=Login+required&state=0c1a9f1d-8614-4158-b02e-f06e8706f5d4
@@ -261,7 +235,8 @@ class JiraHandler:
         screen_tab_ids = self.get_screen_tabs(key)
         headers = {'Content-Type': 'application/json'}
 
-        json_string = u'{"context":{"primary":[{"id":"assignee","type":"FIELD"},{"id":"reporter","type":"FIELD"},{"id":"devSummary","type":"DEV_SUMMARY"},{"id":"customfield_10094","type":"FIELD"},{"id":"customfield_10092","type":"FIELD"},{"id":"customfield_10090","type":"FIELD"},{"id":"customfield_10093","type":"FIELD"},{"id":"customfield_10091","type":"FIELD"},{"id":"labels","type":"FIELD"}],"secondary":[{"id":"priority","type":"FIELD"}],"alwaysHidden":[{"id":"timeoriginalestimate","type":"FIELD"},{"id":"timetracking","type":"FIELD"},{"id":"components","type":"FIELD"},{"id":"fixVersions","type":"FIELD"},{"id":"customfield_10014","type":"FIELD"},{"id":"duedate","type":"FIELD"},{"id":"customfield_10011","type":"FIELD"},{"id":"customfield_10026","type":"FIELD"}]},"content":{"visible":[{"id":"description","type":"FIELD"}],"alwaysHidden":[]}}'
+        #json_string = u'{"context":{"primary":[{"id":"assignee","type":"FIELD"},{"id":"reporter","type":"FIELD"},{"id":"devSummary","type":"DEV_SUMMARY"},{"id":"customfield_10094","type":"FIELD"},{"id":"customfield_10092","type":"FIELD"},{"id":"customfield_10090","type":"FIELD"},{"id":"customfield_10093","type":"FIELD"},{"id":"customfield_10091","type":"FIELD"},{"id":"labels","type":"FIELD"}],"secondary":[{"id":"priority","type":"FIELD"}],"alwaysHidden":[{"id":"timeoriginalestimate","type":"FIELD"},{"id":"timetracking","type":"FIELD"},{"id":"components","type":"FIELD"},{"id":"fixVersions","type":"FIELD"},{"id":"customfield_10014","type":"FIELD"},{"id":"duedate","type":"FIELD"},{"id":"customfield_10011","type":"FIELD"},{"id":"customfield_10026","type":"FIELD"}]},"content":{"visible":[{"id":"description","type":"FIELD"}],"alwaysHidden":[]}}'
+        json_string = u'{"context":{"primary":[{"id":"assignee","type":"FIELD"},{"id":"reporter","type":"FIELD"},{"id":"labels","type":"FIELD"},{"id":"customfield_10101","type":"FIELD"},{"id":"customfield_10103","type":"FIELD"}],"secondary":[{"id":"priority","type":"FIELD"}],"alwaysHidden":[{"id":"timeoriginalestimate","type":"FIELD"},{"id":"timetracking","type":"FIELD"},{"id":"components","type":"FIELD"},{"id":"fixVersions","type":"FIELD"},{"id":"customfield_10014","type":"FIELD"},{"id":"duedate","type":"FIELD"},{"id":"customfield_10011","type":"FIELD"},{"id":"customfield_10026","type":"FIELD"},{"id":"devSummary","type":"DEV_SUMMARY"}]},"content":{"visible":[{"id":"customfield_10104","type":"FIELD"},{"id":"customfield_10102","type":"FIELD"},{"id":"customfield_10100","type":"FIELD"},{"id":"customfield_10105","type":"FIELD"},{"id":"description","type":"FIELD"}],"alwaysHidden":[]}}'
 
         try:
             for screen_tab_id in screen_tab_ids:
@@ -371,7 +346,6 @@ class JiraHandler:
         except Exception as ex:
             traceback.print_exc(file=sys.stdout)
             sys.exit()
-
 
     def get_technique_maturity(self):
 

--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -197,6 +197,7 @@ class JiraHandler:
             traceback.print_exc(file=sys.stdout)
             sys.exit(1)
 
+    """
     def remove_unwanted_fields(self):
 
         print("[*] Removing unwanted fields from ATTACK's default screen tab ...")
@@ -220,6 +221,7 @@ class JiraHandler:
         except Exception as ex:
             traceback.print_exc(file=sys.stdout)
             sys.exit(1)
+    """
 
     def hide_unwanted_fields(self,key):
 
@@ -234,6 +236,28 @@ class JiraHandler:
         try:
             for screen_tab_id in screen_tab_ids:
                 r = requests.put(self.url + '/rest/api/2/project/'+key+'/properties/viewScreenId-'+str(screen_tab_id[0]), data=json_string, headers=headers, auth=(self.username, self.apitoken), verify=False)
+            print("[!] Done.")
+
+        except Exception as ex:
+            print (ex)
+            traceback.print_exc(file=sys.stdout)
+            sys.exit(1)
+    
+    def hide_unwanted_fields2(self,key):
+
+        #https://support.atlassian.com/jira-core-cloud/docs/configure-field-layout-in-the-issue-view/
+        #https://jira.atlassian.com/browse/JRACLOUD-74697?error=login_required&error_description=Login+required&state=0c1a9f1d-8614-4158-b02e-f06e8706f5d4
+
+
+        print("[*] Hiding unnecessary fields from ATTACK's issue layout...")
+        screen_tab_ids = self.get_screen_tabs(key)
+        headers = {'Content-Type': 'application/json'}
+
+        json_string = u'{"context":{"primary":[{"id":"assignee","type":"FIELD"},{"id":"reporter","type":"FIELD"},{"id":"devSummary","type":"DEV_SUMMARY"},{"id":"customfield_10094","type":"FIELD"},{"id":"customfield_10092","type":"FIELD"},{"id":"customfield_10090","type":"FIELD"},{"id":"customfield_10093","type":"FIELD"},{"id":"customfield_10091","type":"FIELD"},{"id":"labels","type":"FIELD"}],"secondary":[{"id":"priority","type":"FIELD"}],"alwaysHidden":[{"id":"timeoriginalestimate","type":"FIELD"},{"id":"timetracking","type":"FIELD"},{"id":"components","type":"FIELD"},{"id":"fixVersions","type":"FIELD"},{"id":"customfield_10014","type":"FIELD"},{"id":"duedate","type":"FIELD"},{"id":"customfield_10011","type":"FIELD"},{"id":"customfield_10026","type":"FIELD"}]},"content":{"visible":[{"id":"description","type":"FIELD"}],"alwaysHidden":[]}}'
+
+        try:
+            for screen_tab_id in screen_tab_ids:
+                r = requests.put(self.url + '/rest/issuedetailslayout/config/classic/screen?projectIdOrKey='+key+'&screenId='+str(screen_tab_id[0]), data=json_string, headers=headers, auth=(self.username, self.apitoken), verify=False)
             print("[!] Done.")
 
         except Exception as ex:


### PR DESCRIPTION
New Features

- MITRE ATT&CK Sub-technique support. Attack2jira will now create sub-techniques as sub-tasks.
- Added 2 new command line parameters 'Project' (-p) and 'Key' (-k)

Enhancements

- Implemented a better way of adding custom fields to the projects Screens. More efficient, less API calls.
- Re-ordered the fields for a better Issue view

Bugs
- Resolved https://github.com/mvelazc0/attack2jira/issues/8
- Resolved https://github.com/mvelazc0/attack2jira/issues/10