### PR TITLE
Fixed issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,70 @@
 # attack2jira
-Updated Version Fixing Several Issues
 
+The MITRE ATT&CK Framework is a great tool security teams can leverage to, among many other things, measure the security posture of an organization against tactics and techniques used in the wild by real threat actors.
 
-The following issues have been found in jirahandler.py, then addresses and fixed:
+At the time of writing, ATT&CK covers 266 Techniques across 12 Tactics. If done manually, tracking this posture's state over time can become a tedious and challenging task. Blue/Purple teams require the proper tools that allow them to efficiently tackle this challenge and focus on whats important.
 
-1) lower() string method was used on dictionary - previously data likely arrived in string format but it apparently changed
+attack2jira automates the process of standing up a Jira environment that can be used to track and measure ATT&CK coverage. No more spreadsheets !
 
-2) overwritten Python "dict" keyword, later creation of dictionary was impossible because of that
+Visit the Wiki to view the [Demos](https://github.com/mvelazc0/attack2jira/wiki/Demos). attack2jira was first presented at [ATT&CKCon 2.0](https://www.youtube.com/watch?v=hrzR8TpnjAw&t=1198s). For more context, read this [blog post](https://medium.com/@mvelazco/tracking-and-measuring-att-ck-coverage-with-attack2jira-fe700e2a1654).
 
-3) get_project_screen_tab_ids() function was operating on the old Jira API endpoint
---> it ended up writing several new function to provide the same functionality (projectid -> screentabids translation)
+To allow the community to experiment with this approach, I created a Jira instance hosting the ATTACK project with attack2jira: [https://attack.atlassian.net](https://attack.atlassian.net/projects/ATT/issues)
 
-4) it looks like the Attack API currently (Jan 2023) provides inconsistent data:
-- datasources obtained via the get_data_sources() function are different than the ones that are returned by get_techniques()
---> that led to errors in creating Jira issues -> completely different set of values of datasources, obtained from get_techniques() was attempted to be mapped on the "datasources" custom field (or more precisely, the field's options to be selected) that had been created based on datasources values taken from get_data_sources() 
+attack2jira was designed to be used with Jira Cloud. Specifically, [Jira Software](https://www.atlassian.com/software). 
+
+Tested on Kali Linux 2018.4 and Windows 10 1830 under Python 3.6 and Python 3.7.
+
+## Quick Start Guide
+
+### Installation
+
+```
+$ git clone https://github.com/mvelazc0/attack2jira.git
+$ pip3 install -r attack2jira/requirements.txt
+```
+ ### Jira Software
+ 
+ - You will need a [Jira Software Cloud](https://www.atlassian.com/software) environment.
+ - You can set up a [free trial](https://www.atlassian.com/software/jira/free) environment for up to 10 users [here](https://www.atlassian.com/try/cloud/signup?bundle=jira-software&edition=free). 
+- Admin access is required
+
+### Usage
+ 
+ Print the help menu
+  ```
+ $ python3 attack2jira.py -h
+ ```
+ 
+ Create the Jira ATTACK project and issues
+ ```
+ $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a initialize
+ ```
+  Create the Jira ATTACK project with custom project and key 
+ ```
+ $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a initialize -p 'ATTACK Coverage' -k ATT
+ ```
+ Export an ATTACK Navigator JSON layer
+ ```
+ $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a export
+ 
+ $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a export -hide
+ ```
+ 
+ ## Demo
+ 
+ [![Demo1 @att&ckcon 2019](https://img.youtube.com/vi/2f6AxLtr_3k/0.jpg)](https://www.youtube.com/watch?v=2f6AxLtr_3k)
+
+ 
+ ## Acknoledgments
+ 
+* [MITRE ATT&CK Framework](https://attack.mitre.org)
+* [ATTACK-Python-Client](https://github.com/hunters-forge/ATTACK-Python-Client)
+ 
+ ## Authors
+
+* **Mauricio Velazco** - [@mvelazco](https://twitter.com/mvelazco)
+* **Olindo Verrillo** - [@olindoverrillo](https://twitter.com/olindoverrillo)
+
+## License
+
+This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -1,70 +1,16 @@
 # attack2jira
+Updated Version Fixing Several Issues
 
-The MITRE ATT&CK Framework is a great tool security teams can leverage to, among many other things, measure the security posture of an organization against tactics and techniques used in the wild by real threat actors.
 
-At the time of writing, ATT&CK covers 266 Techniques across 12 Tactics. If done manually, tracking this posture's state over time can become a tedious and challenging task. Blue/Purple teams require the proper tools that allow them to efficiently tackle this challenge and focus on whats important.
+The following issues have been found in jirahandler.py, then addresses and fixed:
 
-attack2jira automates the process of standing up a Jira environment that can be used to track and measure ATT&CK coverage. No more spreadsheets !
+1) lower() string method was used on dictionary - previously data likely arrived in string format but it apparently changed
 
-Visit the Wiki to view the [Demos](https://github.com/mvelazc0/attack2jira/wiki/Demos). attack2jira was first presented at [ATT&CKCon 2.0](https://www.youtube.com/watch?v=hrzR8TpnjAw&t=1198s). For more context, read this [blog post](https://medium.com/@mvelazco/tracking-and-measuring-att-ck-coverage-with-attack2jira-fe700e2a1654).
+2) overwritten Python "dict" keyword, later creation of dictionary was impossible because of that
 
-To allow the community to experiment with this approach, I created a Jira instance hosting the ATTACK project with attack2jira: [https://attack.atlassian.net](https://attack.atlassian.net/projects/ATT/issues)
+3) get_project_screen_tab_ids() function was operating on the old Jira API endpoint
+--> it ended up writing several new function to provide the same functionality (projectid -> screentabids translation)
 
-attack2jira was designed to be used with Jira Cloud. Specifically, [Jira Software](https://www.atlassian.com/software). 
-
-Tested on Kali Linux 2018.4 and Windows 10 1830 under Python 3.6 and Python 3.7.
-
-## Quick Start Guide
-
-### Installation
-
-```
-$ git clone https://github.com/mvelazc0/attack2jira.git
-$ pip3 install -r attack2jira/requirements.txt
-```
- ### Jira Software
- 
- - You will need a [Jira Software Cloud](https://www.atlassian.com/software) environment.
- - You can set up a [free trial](https://www.atlassian.com/software/jira/free) environment for up to 10 users [here](https://www.atlassian.com/try/cloud/signup?bundle=jira-software&edition=free). 
-- Admin access is required
-
-### Usage
- 
- Print the help menu
-  ```
- $ python3 attack2jira.py -h
- ```
- 
- Create the Jira ATTACK project and issues
- ```
- $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a initialize
- ```
-  Create the Jira ATTACK project with custom project and key 
- ```
- $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a initialize -p 'ATTACK Coverage' -k ATT
- ```
- Export an ATTACK Navigator JSON layer
- ```
- $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a export
- 
- $ python3 attack2jira.py -url https://yourjiracloud.atlassian.net -u user@domain.com -a export -hide
- ```
- 
- ## Demo
- 
- [![Demo1 @att&ckcon 2019](https://img.youtube.com/vi/2f6AxLtr_3k/0.jpg)](https://www.youtube.com/watch?v=2f6AxLtr_3k)
-
- 
- ## Acknoledgments
- 
-* [MITRE ATT&CK Framework](https://attack.mitre.org)
-* [ATTACK-Python-Client](https://github.com/hunters-forge/ATTACK-Python-Client)
- 
- ## Authors
-
-* **Mauricio Velazco** - [@mvelazco](https://twitter.com/mvelazco)
-* **Olindo Verrillo** - [@olindoverrillo](https://twitter.com/olindoverrillo)
-
-## License
-
-This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details
+4) it looks like the Attack API currently (Jan 2023) provides inconsistent data:
+- datasources obtained via the get_data_sources() function are different than the ones that are returned by get_techniques()
+--> that led to errors in creating Jira issues -> completely different set of values of datasources, obtained from get_techniques() was attempted to be mapped on the "datasources" custom field (or more precisely, the field's options to be selected) that had been created based on datasources values taken from get_data_sources() 

--- a/lib/jirahandler.py
+++ b/lib/jirahandler.py
@@ -154,7 +154,6 @@ class JiraHandler:
         try:
 
             # maturity field options
-            # https://a77ackmapp1ng.atlassian.net/rest/api/3/field/customfield_10063/context
             payload=[{"name":"Not Tracked"},{"name":"Initial"},{"name":"Defined"},{"name":"Resilient"},{"name":"Optimized"}]
             r=requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/'+custom_fields['Maturity'], headers=headers, json= payload, auth=(self.username, self.apitoken),verify=False)
             if r.status_code != 204:
@@ -173,7 +172,6 @@ class JiraHandler:
             r = requests.post(self.url + '/rest/globalconfig/1/customfieldoptions/' + custom_fields['Datasources'], headers=headers, json=payload, auth=(self.username, self.apitoken), verify=False)
             if r.status_code != 204:
                 print("[!] Error creating options for the datasources custom field.")
-                print(r)
                 sys.exit()
 
 
@@ -485,7 +483,7 @@ class JiraHandler:
         screen_ids = []
         try:
             for item in screen_scheme_ids:
-                r = requests.get(a.url +'/rest/api/2/screenscheme?id='+item, headers=headers, auth=(a.username, a.apitoken),verify=False)
+                r = requests.get(self.url +'/rest/api/2/screenscheme?id='+item, headers=headers, auth=(self.username, self.apitoken),verify=False)
                 r_dict = r.json()
                 screen_ids.append(list(r_dict['values'][0]['screens'].values())[0])
             return screen_ids
@@ -534,6 +532,7 @@ class JiraHandler:
             print ("[!] Error obtaining issue type screen scheme ids!")
             sys.exit()
     
+    
     def get_screen_tab_ids(self, project_id):
         screen_ids = self.get_screen_ids(project_id)
         screen_tab_ids = []
@@ -548,12 +547,31 @@ class JiraHandler:
             print ("[!] Error obtaining screen tab ids!")
             sys.exit()
 
+
     def get_screen_tab_id(self, screen_id):
         headers = {'Content-Type': 'application/json'}
         try:
             r = requests.get(self.url +'/rest/api/3/screens/'+str(screen_id)+'/tabs', headers=headers, auth=(self.username, self.apitoken), verify=False) 
             resp_dict = r.json()
             return resp_dict[0]['id']
+
+        except:
+            traceback.print_exc(file=sys.stdout)
+            print ("[!] Error obtaining screen/tab ids!")
+            sys.exit()
+            
+            
+    def get_project_screen_tab_ids(self, project_id):
+    #legacy - not used in the current version
+        headers = {'Content-Type': 'application/json'}
+        screen_tab_ids=[]
+        try:
+            r = requests.get(self.url +'/rest/api/3/issuetypescreenscheme/mapping?issueTypeScreenSchemeId='+project_id,headers=headers, auth=(self.username, self.apitoken), verify=False) 
+            resp_dict = r.json()
+            for screen in resp_dict['values']:
+                screen_tab_ids.append([screen['screenSchemeId'], self.get_screen_tab_id(screen['screenSchemeId'])])
+
+            return screen_tab_ids
 
         except:
             traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
The following issues have been identified and fixed in the current version:

**1) get_attack_datasources():**
	Currently the Att&ck API returns different data sources using the get_data_sources() function
comparing to the ones obtained via get_techniques() (more precisely, in the ['x_mitre_data_sources'] key of the objects returned by get_techniques()).
That was the root cause of the issue #17.
To solve the issue and obtain the matching results, I introduced get_techniques() in place of get_data_sources().
First, the technique objects are gathered and then we have the data sources extracted from them and made unique.

I believe the data returned by get_data_sources() (40 records at the time of testing vs over 100 obtained via get_techniques()) is what we get after the update performed last year or so by Mitre.
This is why I named the variable I introduced to store the data sources "data_sources_legacy".

**2) get_project_screen_tab_ids():**
	I found this function to be returning an empty list making the script end in error quite difficult to diagnose at first.
I suspect the Jira API endpoint used in this function may have stopped working properly. I did not find a direct substitution so I had to create a chain of functions to obtain necessary screen tab ids, step by step, initially providing project id, via the following sequence:
	get_project_issue_type_screen_scheme_ids() --> get_screen_scheme_ids() --> get_screen_ids() --> get_screen_tab_ids()

**3) add_custom_fields_to_screen():**
	Folowing up on the thread from 2), the get_project_screen_tab_ids() function was substituted accordingly with newly created get_screen_ids() and get_screen_tab_ids(). Then, I changed a bit the for loop and changed the following '/rest/api/3/screens/'+str(screen_tab_id[0])+'/tabs/'+str(screen_tab_id[1])+'/fields' part in the request into : '/rest/api/3/screens/'+str(screen_ids[i])+'/tabs/'+str(screen_tab_ids[i])+'/fields' which should match better what API expects as input.

**4) in the line 402 of the original jirahandler.py, there is a following code:**
	dict = {'name': datasource.title()}
This overwrites the dict keyword and later on results in an error when creating a dictionary is attempted. I changed the naming such that it does not conflict anymore.